### PR TITLE
CanonicalURLを修正

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -78,7 +78,7 @@ export default Vue.extend({
       link: [
         {
           rel: 'canonical',
-          href: `https://stopcovid19.metro.tokyo.lg.jp${this.$route.path}`
+          href: `https://covid19.codeforkagoshima.dev${this.$route.path}`
         }
       ]
     }

--- a/layouts/print.vue
+++ b/layouts/print.vue
@@ -77,7 +77,7 @@ export default {
       link: [
         {
           rel: 'canonical',
-          href: `https://stopcovid19.metro.tokyo.lg.jp${this.$route.path}`
+          href: `https://covid19.codeforkagoshima.dev${this.$route.path}`
         }
       ]
     }


### PR DESCRIPTION
link rel="canonical" の宛先が東京都のサイトのままになっている為に、検索エンジンやSNSで適用されるリンクも東京都のサイトになってしまう問題の修正です。

---

[PULL_REQUEST_TEMPLATE](
https://github.com/codeforkagoshima/covid19/edit/development/.github/PULL_REQUEST_TEMPLATE.md)には

> Issue 番号がない PR は受け付けません。

とありますが、このリポジトリではissue機能が無効になっているようです。。。