### PR TITLE
サイト名変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# 鹿児島県 新型コロナウイルス感染症対策サイト
+# 鹿児島県新型コロナウイルスまとめサイト
 
 ![](https://github.com/codeforkagoshima/covid19/workflows/production%20deploy/badge.svg)
 
-[![鹿児島県 新型コロナウイルス感染症対策サイト](./static/ogp.png)](https://covid19.codeforkagoshima.dev/)
+[![鹿児島県新型コロナウイルスまとめサイト](./static/ogp.png)](https://covid19.codeforkagoshima.dev/)
 
 ### 日本語 | [English](./README_EN.md)
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -11,7 +11,7 @@ const config: Configuration = {
     htmlAttrs: {
       prefix: 'og: http://ogp.me/ns#'
     },
-    titleTemplate: '%s | 鹿児島県 新型コロナウイルス感染症対策サイト',
+    titleTemplate: '%s | 鹿児島県新型コロナウイルスまとめサイト',
     meta: [
       { charset: 'utf-8' },
       { name: 'viewport', content: 'width=device-width, initial-scale=1' },
@@ -24,7 +24,7 @@ const config: Configuration = {
       {
         hid: 'og:site_name',
         property: 'og:site_name',
-        content: '鹿児島県 新型コロナウイルス感染症対策サイト'
+        content: '鹿児島県新型コロナウイルスまとめサイト'
       },
       { hid: 'og:type', property: 'og:type', content: 'website' },
       {
@@ -35,7 +35,7 @@ const config: Configuration = {
       {
         hid: 'og:title',
         property: 'og:title',
-        content: '鹿児島県 新型コロナウイルス感染症対策サイト'
+        content: '鹿児島県新型コロナウイルスまとめサイト'
       },
       {
         hid: 'og:description',
@@ -107,10 +107,7 @@ const config: Configuration = {
   /*
    ** Nuxt.js dev-modules
    */
-  buildModules: [
-    '@nuxtjs/vuetify',
-    '@nuxt/typescript-build'
-  ],
+  buildModules: ['@nuxtjs/vuetify', '@nuxt/typescript-build'],
   /*
    ** Nuxt.js modules
    */
@@ -217,7 +214,7 @@ const config: Configuration = {
     hardSource: process.env.NODE_ENV === 'development'
   },
   manifest: {
-    name: '鹿児島県 新型コロナウイルス感染症対策サイト',
+    name: '鹿児島県新型コロナウイルスまとめサイト',
     theme_color: '#00a040',
     background_color: '#ffffff',
     display: 'standalone',

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "covid19",
   "version": "1.0.0",
-  "description": "東京都 新型コロナウイルス感染症対策サイト",
+  "description": "鹿児島県新型コロナウイルスまとめサイト",
   "author": "東京都",
   "private": true,
   "engines": {

--- a/pages/cards/_card.vue
+++ b/pages/cards/_card.vue
@@ -148,7 +148,7 @@ export default {
         {
           hid: 'og:title',
           property: 'og:title',
-          content: this.title + ' | 鹿児島県 新型コロナウイルス感染症対策サイト'
+          content: this.title + ' | 鹿児島県新型コロナウイルスまとめサイト'
         },
         {
           hid: 'description',


### PR DESCRIPTION
slack上で議論のあった、サイト名を変更するPull Requestです。

## 👏 解決する issue / Resolved Issues
- close #32

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- サイト名を『鹿児島県 新型コロナウイルス感染症対策サイト	# 鹿児島県新型コロナウイルスまとめサイト』から『鹿児島県新型コロナウイルスまとめサイト』に変更
